### PR TITLE
Allow customization of download location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-check-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install GTK
+        run: sudo apt update && sudo apt install libgtk-3-dev
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f530e4af131d94cc4fa15c5c9d0348f0ef28bac64ba660b6b2a1cf2605dedfce"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +196,16 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ed2639b9ad5f1d6efa76de95558e11339e7318426d84ac4890b86c03e828ca7"
+dependencies = [
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "calloop"
@@ -813,6 +835,7 @@ dependencies = [
  "futures-util",
  "iced",
  "open",
+ "rfd",
  "serde",
  "serde_json",
  "tokio",
@@ -1026,6 +1049,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk-pixbuf-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bfe468a7f43e97b8d193a762b6c5cf67a7d36cacbc0b9291dbcae24bfea1e8f"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9653cfc500fd268015b1ac055ddbc3df7a5c9ea3f4ccef147b3957bd140d69"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,12 +1267,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e24fb752f8f5d2cf6bbc2c606fd2bc989c81c5e2fe321ab974d54f8b6344eac"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "glam"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579160312273c954cc51bd440f059dde741029ac8daf8c84fece76cb77f62c15"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e9b997a66e9a23d073f2b1abb4dbfc3925e0b8952f67efd8d9b6e168e4cdc1"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1274,6 +1350,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "952133b60c318a62bf82ee75b93acc7e84028a093e06b9e27981c2b6fe68218c"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gpu-alloc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1402,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gtk-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89acda6f084863307d948ba64a4b1ef674e8527dddab147ee4cdcc194c880457"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
 name = "guillotiere"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1455,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2227,6 +2341,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pango-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d2650c8b62d116c020abd0cea26a4ed96526afda89b1c4ea567131fdefc890"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2786,29 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rfd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1084e570d9ce1890734b33edd8c1a7b7276076f9610fa23a48aa955587da141"
+dependencies = [
+ "block",
+ "dispatch",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "lazy_static",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3125,6 +3274,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "strum"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
+
+[[package]]
+name = "strum_macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,6 +3306,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "system-deps"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3ecc17269a19353b3558b313bba738b25d82993e30d62a18406a24aba4649b"
+dependencies = [
+ "heck",
+ "pkg-config",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "toml",
+ "version-compare",
 ]
 
 [[package]]
@@ -3457,6 +3639,12 @@ name = "vcpkg"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
+
+[[package]]
+name = "version-compare"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ fluminurs = { git = "https://github.com/bnjmnt4n/fluminurs", branch = "desktop" 
 futures-util = "0.3"
 iced = { version = "0.3", features = ["tokio"] }
 open = "1.7"
+rfd = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       nativeBuildInputs = with pkgs; [ cmake openssl pkg-config ];
       buildInputs = with pkgs; [
         openssl freetype expat vulkan-loader vulkan-tools
-        wayland wayland-protocols libxkbcommon
+        wayland wayland-protocols libxkbcommon gtk3
       ] ++ (with xorg; [
         libX11 libXcursor libXrandr libXi
       ]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ impl Application for FluminursDesktop {
             Page::Settings => self
                 .pages
                 .settings
-                .view(&self.settings, logged_in)
+                .view(&mut self.settings, logged_in)
                 .map(Message::SettingsPage),
             Page::Modules => self
                 .pages

--- a/src/message.rs
+++ b/src/message.rs
@@ -15,7 +15,7 @@ use crate::pages::resources::{ResourcesMessage, ResourcesPage};
 use crate::pages::settings::SettingsMessage;
 use crate::pages::Page;
 use crate::resource::{ResourceMessage, ResourceState, ResourceType};
-use crate::settings::Settings;
+use crate::settings::{default_download_dir, Settings};
 use crate::storage::{Storage, StorageWrite};
 use crate::utils::{clean_username, construct_modules_map, merge_modules, merge_resources};
 use crate::Error;
@@ -31,8 +31,11 @@ pub enum Message {
     Header(HeaderMessage),
     SwitchPage(Page),
 
+    // Settings
     ToggleSaveUsername(bool),
     ToggleSavePassword(bool),
+    ChangeDownloadLocation(()),
+    DownloadLocationChanged(PathBuf),
 
     Startup((Result<Settings, Error>, Result<Data, Error>)),
     SettingsSaved(Result<StorageWrite, Error>),
@@ -390,6 +393,45 @@ pub fn handle_message(state: &mut FluminursDesktop, message: Message) -> Command
             state.data.mark_dirty();
 
             Command::perform(state.data.save(), Message::DataSaved)
+        }
+
+        Message::ChangeDownloadLocation(()) => {
+            let curr_download_dir =
+                if let Some(download_dir) = state.settings.get_download_location() {
+                    download_dir.to_owned()
+                } else {
+                    default_download_dir()
+                };
+
+            let task = rfd::AsyncFileDialog::new()
+                .set_directory(curr_download_dir.clone())
+                .pick_folder();
+
+            Command::perform(
+                async move {
+                    let folder = task.await;
+
+                    if let Some(folder) = folder {
+                        #[cfg(not(target_arch = "wasm32"))]
+                        folder.path().to_path_buf()
+                    } else {
+                        curr_download_dir
+                    }
+                },
+                Message::DownloadLocationChanged,
+            )
+        }
+
+        Message::DownloadLocationChanged(location) => {
+            state.settings.set_download_location(location);
+
+            Command::batch(vec![
+                Command::perform(state.settings.save(), Message::SettingsSaved),
+                Command::perform(
+                    async { SettingsMessage::DownloadLocationChanged },
+                    Message::SettingsPage,
+                ),
+            ])
         }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -320,6 +320,7 @@ pub fn handle_message(state: &mut FluminursDesktop, message: Message) -> Command
                 match api {
                     Some(api) => {
                         let modules_map = state.modules_map.clone();
+                        let download_dir = state.settings.get_download_location().clone();
                         let resources = get_resources_items(state, resource_type);
                         resources
                             .iter_mut()
@@ -338,6 +339,7 @@ pub fn handle_message(state: &mut FluminursDesktop, message: Message) -> Command
                                                 let result = api::download_resource(
                                                     api,
                                                     resource,
+                                                    download_dir.clone(),
                                                     download_path,
                                                     path.clone(),
                                                 )

--- a/src/pages/settings.rs
+++ b/src/pages/settings.rs
@@ -10,6 +10,8 @@ use crate::settings::Settings;
 #[derive(Debug, Clone)]
 pub struct SettingsPage {
     login_button: button::State,
+    download_location_button: button::State,
+    is_changing_download_location: bool,
     scroll: scrollable::State,
 }
 
@@ -18,12 +20,16 @@ pub enum SettingsMessage {
     SwitchPage(Page),
     ToggleSaveUsername(bool),
     ToggleSavePassword(bool),
+    ChangeDownloadLocation,
+    DownloadLocationChanged,
 }
 
 impl SettingsPage {
     pub fn default() -> Self {
         SettingsPage {
             login_button: button::State::new(),
+            download_location_button: button::State::new(),
+            is_changing_download_location: false,
             scroll: scrollable::State::new(),
         }
     }
@@ -39,10 +45,18 @@ impl SettingsPage {
             SettingsMessage::ToggleSavePassword(save_password) => {
                 Command::perform(async move { save_password }, Message::ToggleSavePassword)
             }
+            SettingsMessage::ChangeDownloadLocation => {
+                self.is_changing_download_location = true;
+                Command::perform(async {}, Message::ChangeDownloadLocation)
+            }
+            SettingsMessage::DownloadLocationChanged => {
+                self.is_changing_download_location = false;
+                Command::none()
+            }
         }
     }
 
-    pub fn view(&mut self, settings: &Settings, logged_in: bool) -> Element<SettingsMessage> {
+    pub fn view(&mut self, settings: &mut Settings, logged_in: bool) -> Element<SettingsMessage> {
         let login_element: Element<_> = if logged_in {
             Text::new("Logged in").into()
         } else {
@@ -88,11 +102,42 @@ impl SettingsPage {
                 .into()
         };
 
+        let download_location_details: Element<SettingsMessage> = {
+            let download_location: Element<_> =
+                if let Some(download_location) = settings.get_download_location() {
+                    Text::new(download_location.to_string_lossy()).into()
+                } else {
+                    Text::new("No download location specified").into()
+                };
+
+            let download_location_button =
+                Button::new(&mut self.download_location_button, Text::new("Change…"));
+
+            // Disable change button if dialog is currently open/opening.
+            // TODO: opening the dialog seems to take a bit of time on my Linux system.
+            let download_location_button = if self.is_changing_download_location {
+                download_location_button
+            } else {
+                download_location_button.on_press(SettingsMessage::ChangeDownloadLocation)
+            };
+
+            Row::new()
+                .height(Length::Units(30))
+                .align_items(Align::Center)
+                .spacing(20)
+                .push(Text::new("Download location"))
+                .push(download_location)
+                .push(download_location_button)
+                .into()
+        };
+
         let content = Column::new()
             .spacing(20)
             .push(login_element)
             .push(save_username_row)
-            .push(save_password_row);
+            .push(save_password_row)
+            .push(download_location_details)
+            .push(Text::new("Note: changing the download location will not shift files from the old location to the new one."));
 
         let scrollable =
             Scrollable::new(&mut self.scroll).push(Container::new(content).width(Length::Fill));

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,7 +10,7 @@ pub struct Settings {
     password: Option<String>,
     save_username: bool,
     save_password: bool,
-    download_location: Option<String>,
+    download_location: Option<PathBuf>,
 
     #[serde(skip)]
     dirty: bool,
@@ -26,7 +26,7 @@ impl Settings {
             // Default to saving username but not password
             save_username: true,
             save_password: false,
-            download_location: None,
+            download_location: Some(default_download_dir()),
             dirty: false,
             saving: false,
         }
@@ -62,6 +62,11 @@ impl Settings {
         self.dirty = true;
     }
 
+    pub fn set_download_location(&mut self, download_location: PathBuf) {
+        self.download_location = Some(download_location);
+        self.dirty = true;
+    }
+
     pub fn get_username(&self) -> &Option<String> {
         &self.username
     }
@@ -76,6 +81,10 @@ impl Settings {
 
     pub fn get_save_password(&self) -> bool {
         self.save_password
+    }
+
+    pub fn get_download_location(&self) -> &Option<PathBuf> {
+        &self.download_location
     }
 }
 
@@ -94,4 +103,15 @@ impl Storage for Settings {
     fn get_saving(&mut self) -> &mut bool {
         &mut self.saving
     }
+}
+
+pub fn default_download_dir() -> PathBuf {
+    let mut download_dir: PathBuf = directories::UserDirs::new()
+        .unwrap()
+        .download_dir()
+        .unwrap()
+        .into();
+    download_dir.push("LumiNUS");
+
+    download_dir
 }


### PR DESCRIPTION
This adds a new setting which allows customization of the download location, using `rfd` to open a native folder selection dialog.

Note: on my Linux system, it can take up to 2 seconds to show the GTK dialog, so I've ensured that the button to open the dialog is disabled after the first click to prevent multiple dialogs from appearing.

Todo:
- [ ] Test on macOS
- [ ] Test on Windows (low priority for now)

This is currently stacked on #19.

Closes #16.