### PR TITLE
Settings: add save username/password options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ impl Application for FluminursDesktop {
             Page::Settings => self
                 .pages
                 .settings
-                .view(logged_in)
+                .view(&self.settings, logged_in)
                 .map(Message::SettingsPage),
             Page::Modules => self
                 .pages

--- a/src/message.rs
+++ b/src/message.rs
@@ -31,6 +31,9 @@ pub enum Message {
     Header(HeaderMessage),
     SwitchPage(Page),
 
+    ToggleSaveUsername(bool),
+    ToggleSavePassword(bool),
+
     Startup((Result<Settings, Error>, Result<Data, Error>)),
     SettingsSaved(Result<StorageWrite, Error>),
     DataSaved(Result<StorageWrite, Error>),
@@ -61,6 +64,16 @@ pub fn handle_message(state: &mut FluminursDesktop, message: Message) -> Command
         Message::SwitchPage(page) => {
             state.current_page = page;
             Command::none()
+        }
+
+        // Toggling the save username/password settings.
+        Message::ToggleSaveUsername(save_username) => {
+            state.settings.set_save_username(save_username);
+            Command::perform(state.settings.save(), Message::SettingsSaved)
+        }
+        Message::ToggleSavePassword(save_password) => {
+            state.settings.set_save_password(save_password);
+            Command::perform(state.settings.save(), Message::SettingsSaved)
         }
 
         Message::Startup((settings, data)) => {

--- a/src/pages/settings.rs
+++ b/src/pages/settings.rs
@@ -1,10 +1,11 @@
 use iced::{
-    button, scrollable, Align, Button, Column, Command, Container, Element, Length, Row,
+    button, scrollable, Align, Button, Checkbox, Column, Command, Container, Element, Length, Row,
     Scrollable, Text,
 };
 
 use crate::message::Message;
 use crate::pages::Page;
+use crate::settings::Settings;
 
 #[derive(Debug, Clone)]
 pub struct SettingsPage {
@@ -15,6 +16,8 @@ pub struct SettingsPage {
 #[derive(Debug, Clone)]
 pub enum SettingsMessage {
     SwitchPage(Page),
+    ToggleSaveUsername(bool),
+    ToggleSavePassword(bool),
 }
 
 impl SettingsPage {
@@ -30,10 +33,16 @@ impl SettingsPage {
             SettingsMessage::SwitchPage(page) => {
                 Command::perform(async { page }, Message::SwitchPage)
             }
+            SettingsMessage::ToggleSaveUsername(save_username) => {
+                Command::perform(async move { save_username }, Message::ToggleSaveUsername)
+            }
+            SettingsMessage::ToggleSavePassword(save_password) => {
+                Command::perform(async move { save_password }, Message::ToggleSavePassword)
+            }
         }
     }
 
-    pub fn view(&mut self, logged_in: bool) -> Element<SettingsMessage> {
+    pub fn view(&mut self, settings: &Settings, logged_in: bool) -> Element<SettingsMessage> {
         let login_element: Element<_> = if logged_in {
             Text::new("Logged in").into()
         } else {
@@ -49,7 +58,41 @@ impl SettingsPage {
                 .into()
         };
 
-        let content = Column::new().spacing(20).push(login_element);
+        let save_username_row: Element<_> = {
+            let checkbox = Checkbox::new(
+                settings.get_save_username(),
+                "Save username",
+                SettingsMessage::ToggleSaveUsername,
+            )
+            .width(Length::Fill);
+
+            Row::new()
+                .spacing(20)
+                .align_items(Align::Center)
+                .push(checkbox)
+                .into()
+        };
+
+        let save_password_row: Element<_> = {
+            let checkbox = Checkbox::new(
+                settings.get_save_password(),
+                "Save password",
+                SettingsMessage::ToggleSavePassword,
+            )
+            .width(Length::Fill);
+
+            Row::new()
+                .spacing(20)
+                .align_items(Align::Center)
+                .push(checkbox)
+                .into()
+        };
+
+        let content = Column::new()
+            .spacing(20)
+            .push(login_element)
+            .push(save_username_row)
+            .push(save_password_row);
 
         let scrollable =
             Scrollable::new(&mut self.scroll).push(Container::new(content).width(Length::Fill));

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -32,6 +32,26 @@ impl Settings {
         }
     }
 
+    pub fn set_save_username(&mut self, save_username: bool) {
+        if self.save_username != save_username {
+            self.save_username = save_username;
+            if !save_username && self.username.is_some() {
+                self.username = None;
+            }
+            self.dirty = true;
+        }
+    }
+
+    pub fn set_save_password(&mut self, save_password: bool) {
+        if self.save_password != save_password {
+            self.save_password = save_password;
+            if !save_password && self.password.is_some() {
+                self.password = None;
+            }
+            self.dirty = true;
+        }
+    }
+
     pub fn set_login_details(&mut self, username: String, password: String) {
         if self.save_username {
             self.username = Some(username);
@@ -48,6 +68,14 @@ impl Settings {
 
     pub fn get_password(&self) -> &Option<String> {
         &self.password
+    }
+
+    pub fn get_save_username(&self) -> bool {
+        self.save_username
+    }
+
+    pub fn get_save_password(&self) -> bool {
+        self.save_password
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,8 @@ use crate::storage::{get_project_dirs, Storage};
 pub struct Settings {
     username: Option<String>,
     password: Option<String>,
+    save_username: bool,
+    save_password: bool,
     download_location: Option<String>,
 
     #[serde(skip)]
@@ -21,6 +23,9 @@ impl Settings {
         Settings {
             username: None,
             password: None,
+            // Default to saving username but not password
+            save_username: true,
+            save_password: false,
             download_location: None,
             dirty: false,
             saving: false,
@@ -28,8 +33,12 @@ impl Settings {
     }
 
     pub fn set_login_details(&mut self, username: String, password: String) {
-        self.username = Some(username);
-        self.password = Some(password);
+        if self.save_username {
+            self.username = Some(username);
+        }
+        if self.save_password {
+            self.password = Some(password);
+        }
         self.dirty = true;
     }
 


### PR DESCRIPTION
This adds 2 new settings which allows customization of whether to save username and password credentials.

This is currently stacked on #19.

Closes #15.